### PR TITLE
chore: TypeScript 7移行準備でtypesを明示設定

### DIFF
--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -2,6 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": ["@tsconfig/node24/tsconfig.json"],
   "compilerOptions": {
-    "types": ["vitest/globals"]
+    "types": ["node", "vitest/globals"]
   }
 }


### PR DESCRIPTION
## 概要
TypeScript 7 ではデフォルト値が変更されるため、事前に明示的な設定を追加する。

## 変更内容
- `packages/typescript-config/base.json`: `types` に `"node"` を追加（v7 でデフォルトが `[]` になるため）

## テスト
- `turbo type-check --force` 全パッケージ成功確認済み